### PR TITLE
Fix for CWE-863: Incorrect Authorization

### DIFF
--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -93,7 +93,7 @@ func handleCreate(ctx context.Context, req *logical.Request, data *framework.Fie
 		return nil, err
 	}
 	if !slices.Contains(c.Scopes, scope) {
-		return nil, err
+	 return nil, fmt.Errorf("requested scope %q is not permitted for user %q", scope, u)
 	}
 
 	dc := dockerhub.Client{


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in internal/token/token.go.

It is CWE-863: Incorrect Authorization that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix ensures that when a user requests a scope not included in their allowed scopes, an explicit error is returned instead of a generic error, preventing unauthorized access by clearly denying invalid scope requests.<br>The original code returned a generic error with &quot;return nil, err&quot;, which may be unclear or improperly handled.<br>    The fix replaces this with &quot;return nil, fmt.Errorf(&quot;requested scope %q is not permitted for user %q&quot;, scope, u)&quot; to explicitly deny unauthorized scopes.<br>    This change makes the authorization failure explicit, improving error clarity and preventing silent or incorrect authorization success.<br>    The check uses &quot;slices.Contains(c.Scopes, scope)&quot; to validate the requested scope against the user&#x27;s permitted scopes.

### 💡 Important Instructions
Ensure that the caller of this function correctly handles the new explicit error message and does not proceed with token creation when the error indicates unauthorized scope.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/31340272-28b9-4352-a07f-dd3db65b38f9)

